### PR TITLE
c Syntax in lua Syntax umgewandelt.

### DIFF
--- a/S5Updater/UserScript.lua
+++ b/S5Updater/UserScript.lua
@@ -1,6 +1,6 @@
 ﻿
 
-// Do not download this file raw from GitHub. it will not work. (Missing config and wring line endings.)
+-- Do not download this file raw from GitHub. it will not work. (Missing config and wring line endings.)
 
 if UserScript then
     return


### PR DESCRIPTION
die // sind keine lua Syntax und schmeißen deshalb einen Fehler. // wurde zu -- ersetzt.
WIrd nur bei bereits heruntergeladenen UserScripten zu Fehlern führen.